### PR TITLE
switches automation to automatically cut releases (not drafts)

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,4 +1,4 @@
-name: Create Draft Release
+name: Create Release
 
 on:
   push:
@@ -65,4 +65,4 @@ jobs:
         target_commitish: ${{ github.sha }}
         name: v${{ steps.tag.outputs.tag }}
         body: "See builder.toml file"
-        draft: true
+        draft: false


### PR DESCRIPTION
For now, we want this process entirely automated. The releases will always bump the patch version of the builder. There may be an upcoming RFC to propose stricter semver versioning rules for builders.