### PR TITLE
Push full cf tag to GCR and Cloudfoundry Dockerhub

### DIFF
--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -33,6 +33,14 @@ jobs:
 
     - name: Push
       env:
+        GCR_PUSH_BOT_JSON_KEY: ${{ secrets.GCR_PUSH_BOT_JSON_KEY }}
+      run: |
+        echo "${GCR_PUSH_BOT_JSON_KEY}" | docker login --username _json_key --password-stdin gcr.io
+        docker tag builder "gcr.io/paketo-buildpacks/builder:full-cf"
+        docker push "gcr.io/paketo-buildpacks/builder:full-cf"
+
+    - name: Push
+      env:
         PAKETO_BUILDPACKS_DOCKERHUB_USERNAME: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_USERNAME }}
         PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD: ${{ secrets.PAKETO_BUILDPACKS_DOCKERHUB_PASSWORD }}
       run: |

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -37,6 +37,7 @@ jobs:
       run: |
         echo "${GCR_PUSH_BOT_JSON_KEY}" | docker login --username _json_key --password-stdin gcr.io
         docker tag builder "gcr.io/paketo-buildpacks/builder:full-cf"
+
         docker push "gcr.io/paketo-buildpacks/builder:full-cf"
 
     - name: Push
@@ -52,3 +53,16 @@ jobs:
         docker push "paketobuildpacks/builder:full"
         docker push "paketobuildpacks/builder:full-cf"
         docker push "paketobuildpacks/builder:${{ steps.event.outputs.tag }}-full"
+
+    - name: Push
+      env:
+        CLOUDFOUNDRY_DOCKERHUB_USERNAME: ${{ secrets.CLOUDFOUNDRY_DOCKERHUB_USERNAME }}
+        CLOUDFOUNDRY_DOCKERHUB_PASSWORD: ${{ secrets.CLOUDFOUNDRY_DOCKERHUB_PASSWORD }}
+      run: |
+        echo "${CLOUDFOUNDRY_DOCKERHUB_PASSWORD}" | docker login --username "${CLOUDFOUNDRY_DOCKERHUB_USERNAME}" --password-stdin
+        docker tag builder "cloudfoundry/cnb:full-cf"
+        docker tag builder "cloudfoundry/cnb:cflinuxfs3"
+
+        docker push "cloudfoundry/cnb:full-cf"
+        docker push "cloudfoundry/cnb:cflinuxfs3"
+


### PR DESCRIPTION
Since the full builder is now taking the place of the full-cf builder, to maintain continuity the `full-cf` tag should also be pushed to GCR and the Cloudfoundry Dockerhub and the `cflinuxfs3` tag should also get pushed to the Cloudfoundry Dockerhub.

**Important**: this cannot be merged until the secrets for the Cloudfoundry Dockerhub are added to this repo.