### PR TITLE
use release-drafter instead of Paketo GHA

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,3 +1,5 @@
 CODEOWNERS
 dependabot.yml
 workflows/push-image.yml
+workflows/create-release.yml
+release-drafter-config.yml

--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,0 +1,25 @@
+# Config for https://github.com/release-drafter/release-drafter
+name-template: '$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+filter-by-commitish: true
+commitish: main
+
+change-template: '- $TITLE [#$NUMBER] by [@$AUTHOR](https://github.com/$AUTHOR)'
+template: |
+  ## Full Changelog
+
+  Following pull requests got merged for this release:
+
+  $CHANGES
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Get pack version
       id: pack-version
-      run : |
+      run: |
         version=$(jq -r .pack "scripts/.util/tools.json")
         echo "::set-output name=version::${version#v}"
 
@@ -38,10 +38,13 @@ jobs:
     - name: Generate Release Notes
       id: notes
       run: |
-        notes="$(pack inspect-builder builder | grep -v 'Inspecting builder' | grep -v 'REMOTE:' | grep -v 'LOCAL:' | grep -v '\(not present\)' | sed -e '/./,$!d')"
-        notes="${notes//'%'/'%25'}"
-        notes="${notes//$'\n'/'%0A'}"
-        notes="${notes//$'\r'/'%0D'}"
+        notes="$(pack inspect-builder builder | grep -v 'Inspecting builder' \
+          | grep -v 'REMOTE:' \
+          | grep -v 'LOCAL:' \
+          | grep -v '\(not present\)' \
+          | grep -v 'Warning' \
+          | sed -e '/./,$!d' \
+          | awk -F, '{printf "%s\\n", $0}')"
         echo "::set-output name=body::${notes}"
 
   release:
@@ -52,7 +55,7 @@ jobs:
     - name: Checkout With History
       uses: actions/checkout/@v2
       with:
-        fetch-depth: 0 # gets full history
+        fetch-depth: 0  # gets full history
     - name: Compare With Previous Release
       id: compare_previous_release
       run: |
@@ -62,21 +65,28 @@ jobs:
         else
           echo "::set-output name=builder_changes::true"
         fi
-    - name: Tag
-      id: tag
+    - name: Publish Release
+      id: publish
       if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
-      uses: paketo-buildpacks/github-config/actions/tag/increment-tag@main
-    - name: Create Release
-      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
-      uses: paketo-buildpacks/github-config/actions/release/create@main
+      uses: release-drafter/release-drafter@v5
       with:
-        repo: ${{ github.repository }}
-        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-        tag_name: v${{ steps.tag.outputs.tag }}
-        target_commitish: ${{ github.sha }}
-        name: v${{ steps.tag.outputs.tag }}
-        body: |
-          ```
-          ${{ needs.smoke.outputs.release_notes }}
-          ```
-        draft: false
+        config-name: release-drafter-config.yml
+        publish: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    - name: Update Release Notes
+      if: ${{ steps.compare_previous_release.outputs.builder_changes == 'true' }}
+      run: |
+        set -e
+        payload="{\"body\" : \"\`\`\`\n${RELEASE_BODY}\n\`\`\`\"}"
+
+        curl --fail \
+          -X PATCH \
+          -H "Accept: application/vnd.github.v3+json" \
+          -H "Authorization: token ${GITHUB_TOKEN}" \
+          "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" \
+          -d "${payload}"
+      env:
+        RELEASE_ID: ${{ steps.publish.outputs.id }}
+        RELEASE_BODY: ${{ needs.smoke.outputs.release_notes }}
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/push-image.yml
+++ b/.github/workflows/push-image.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Get pack version
       id: pack-version
-      run : |
+      run: |
         version=$(jq -r .pack "scripts/.util/tools.json")
         echo "::set-output name=version::${version#v}"
 
@@ -69,4 +69,3 @@ jobs:
 
         docker push "cloudfoundry/cnb:full-cf"
         docker push "cloudfoundry/cnb:cflinuxfs3"
-


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
In order to implement [RFC #30](https://github.com/paketo-buildpacks/rfcs/blob/93812669fa43aaf43aa24195689280e9ede591db/text/0030-buildpackless-builders.md) Buildpackless Builders, we'll need to use a more sophisticated release drafter than the Paketo GHA that can handle semver version resolution for 2 version lines in the same repository. Rather than add complexity to the Paketo GHA, I've opted to move the full builder (as a test) to [this release drafter action](https://github.com/release-drafter/release-drafter). It's currently used by the Java buldpacks for this purpose.

One drawback is that the action doesn't accept release notes body as input (and the maintainers are [opposed to adding this feature](https://github.com/release-drafter/release-drafter/issues/893)). As a result, the updated release workflow publishes the release and then edits the release notes after the fact to include the `pack inspect-builder` output.

However, the action will enable us to automatically version the regular and buildpackless builders within the same repo _and_ has support for semver versioning based on merged-PR-labels (patch, minor, major). This will help implement [RFC#29](https://github.com/paketo-buildpacks/rfcs/blob/93812669fa43aaf43aa24195689280e9ede591db/text/0029-semantic-versioning.md) Semantic Versioning.

The PR also adds the release drafter config file and create-release workflows to the syncignore.

You can see an example of this workflow in action [in this fork of the tiny builder repo](https://github.com/fg-j/tiny-builder)

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
