### PR TITLE
Fix tag template for release drafter

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,6 +1,6 @@
 # Config for https://github.com/release-drafter/release-drafter
 name-template: '$RESOLVED_VERSION'
-tag-template: '$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
 filter-by-commitish: true
 commitish: main
 


### PR DESCRIPTION
So that release drafter detects previous release and happily cuts a new one

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The release drafter is currently failing because it can't find a previous release matching the expected version scheme (see https://github.com/paketo-buildpacks/full-builder/runs/2943285292?check_suite_focus=true#step:4:17). This is because of a typo in the workflow that's fixed here.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
