### PR TITLE
add initial buildpackless automation

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -2,4 +2,6 @@ CODEOWNERS
 dependabot.yml
 workflows/push-image.yml
 workflows/create-release.yml
+workflows/buildpackless-update-builder-toml.yml
 release-drafter-config.yml
+release-drafter-config-buildpackless.yml

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  target-branch: "buildpackless"
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  labels:
+  - "buildpackless"

--- a/.github/release-drafter-config-buildpackless.yml
+++ b/.github/release-drafter-config-buildpackless.yml
@@ -1,0 +1,25 @@
+# Config for https://github.com/release-drafter/release-drafter
+name-template: '$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+filter-by-commitish: true
+commitish: buildpackless
+
+change-template: '- $TITLE [#$NUMBER] by [@$AUTHOR](https://github.com/$AUTHOR)'
+template: |
+  ## Full Changelog
+
+  Following pull requests got merged for this release:
+
+  $CHANGES
+
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
     - main
+    - buildpackless
 
 jobs:
 

--- a/.github/workflows/update-builder-toml-buildpackless.yml
+++ b/.github/workflows/update-builder-toml-buildpackless.yml
@@ -1,0 +1,49 @@
+name: Update builder.toml and Send Pull Request
+
+on:
+  schedule:
+  - cron: '*/15 * * * *'
+  workflow_dispatch: {}
+
+jobs:
+  update:
+    name: Update builder.toml
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out
+      uses: actions/checkout@v2
+      with:
+        ref: buildpackless
+
+
+    - name: Checkout branch
+      uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+      with:
+        branch: "automation/bpless-builder-toml"
+
+    - name: Update builder.toml
+      uses: paketo-buildpacks/github-config/actions/builder/update@main
+
+    - name: Git commit
+      id: commit
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      with:
+        message: "Update buildpackless builder.toml"
+        pathspec: "builder.toml"
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
+
+    - name: Git push
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: "automation/bpless-builder-toml"
+
+    - name: Open Pull Request
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        title: "Updating buildpackless builder.toml"
+        branch: "automation/buildpackless-builder-toml"
+        base: "buildpackless"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR makes changes to the automation on this repo to enable
- running smoke tests against PRs to `buildpackless` protected mainline branch
- updating the `builder.toml` on the `buildpackless` branch
- getting dependabot updates on the `buildpackless` branch

This does **not** set up
- cutting buildpackless releases
- pushing buildpackless builders
- syncing buildpackless `.github/` and `scripts/` with anything in the github-config repo

## Use Cases
<!-- An explanation of the use cases your change enables -->
These changes are necessary to implement the [Buildpackless Builders RFC](https://github.com/paketo-buildpacks/rfcs/blob/99cbb329ee847a4c025ca8ca41b0e88b863ce9e9/text/0030-buildpackless-builders.md) for the full builder.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
