### PR TITLE
Auto merge bot PRs to buildpackless branch

### DIFF
--- a/.github/workflows/approve-bot-pr.yml
+++ b/.github/workflows/approve-bot-pr.yml
@@ -1,0 +1,62 @@
+name: Approve Bot PRs
+
+on:
+  workflow_run:
+    workflows: ["Test Pull Request"]
+    types:
+    - completed
+
+jobs:
+  download:
+    name: Download PR Artifact
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    outputs:
+      pr-author: ${{ steps.pr-data.outputs.author }}
+      pr-number: ${{ steps.pr-data.outputs.number }}
+    steps:
+    - name: 'Download artifact'
+      uses: paketo-buildpacks/github-config/actions/pull-request/download-artifact@main
+      with:
+        name: "event-payload"
+        repo: ${{ github.repository }}
+        run_id: ${{ github.event.workflow_run.id }}
+        workspace: "/github/workspace"
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+    - id: pr-data
+      run: |
+        echo "::set-output name=author::$(cat event.json | jq -r '.pull_request.user.login')"
+        echo "::set-output name=number::$(cat event.json | jq -r '.pull_request.number')"
+
+  approve:
+    name: Approve Bot PRs
+    needs: download
+    if: ${{ needs.download.outputs.pr-author == 'paketo-bot' || needs.download.outputs.pr-author == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check Commit Verification
+      id: unverified-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-unverified-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Check for Human Commits
+      id: human-commits
+      uses: paketo-buildpacks/github-config/actions/pull-request/check-human-commits@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        number: ${{ needs.download.outputs.pr-number }}
+
+    - name: Checkout
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: actions/checkout@v2
+
+    - name: Approve
+      if: steps.human-commits.outputs.human_commits == 'false' && steps.unverified-commits.outputs.unverified_commits == 'false'
+      uses: paketo-buildpacks/github-config/actions/pull-request/approve@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_REVIEWER_GITHUB_TOKEN }}
+        number: ${{ needs.download.outputs.pr-number }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,44 @@
+name: Auto-Merge
+
+on:
+  pull_request_review:
+    types:
+    - submitted
+
+jobs:
+  automerge:
+    name: Merge or Rebase
+    if: ${{ github.event.review.user.login == 'paketo-bot-reviewer' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Fetch Pull Request Details
+      id: pull_request
+      env:
+        NUMBER: ${{ github.event.pull_request.number }}
+        GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+      run: |
+        payload="$(
+          curl "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${NUMBER}" \
+            --silent \
+            --location \
+            --header "Authorization: token ${GITHUB_TOKEN}"
+        )"
+
+        echo "::set-output name=mergeable_state::$(echo "${payload}" | jq -r -c .mergeable_state)"
+
+    - name: Merge
+      if: ${{ steps.pull_request.outputs.mergeable_state == 'clean' || steps.pull_request.outputs.mergeable_state == 'unstable' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/merge@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        number: ${{ github.event.pull_request.number }}
+
+    - name: Rebase
+      if: ${{ steps.pull_request.outputs.mergeable_state == 'behind' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/rebase@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Use Cases
<!-- An explanation of the use cases your change enables -->
The approve-bot-pr and auto-merge workflows need to be present on the `buildpackless` branch in order for automation PRs to the `buildpackless` branch to merge automatically, as they do for the `main` branch.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
