### PR TITLE
Use centralized release automation

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,5 +1,3 @@
 CODEOWNERS
 dependabot.yml
 workflows/push-image.yml
-workflows/create-release.yml
-release-drafter-config.yml


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
As of https://github.com/paketo-buildpacks/github-config/pull/440, all builders are set up to use the release-drafter automation that has been running in this repo for a while. Thus, the release automation files can be removed from this repo's syncignore.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
