### PR TITLE
Adds watchexec as optional in httpd group

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -86,6 +86,11 @@ description = "Ubuntu bionic base image with buildpacks for Java, .NET Core, Nod
 [[order]]
 
   [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    version = "2.3.3"
+    optional = true
+
+  [[order.group]]
     id = "paketo-buildpacks/httpd"
     version = "0.3.0"
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

The `httpd` buildpack has added support for `watchexec` live reloading. This means that its group will need to optionally include the `watchexec` buildpack. This will serve as a stop-gap modification to the builder until the `web-servers` buildpack is ready for prime time.

Resolves https://github.com/paketo-buildpacks/httpd/issues/297

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
