### PR TITLE
Add watchexec as optional to nginx order group

### DIFF
--- a/builder.toml
+++ b/builder.toml
@@ -44,6 +44,10 @@ description = "Ubuntu bionic base image with buildpacks for Java, .NET Core, Nod
   uri = "docker://gcr.io/paketo-buildpacks/ruby:0.11.0"
   version = "0.11.0"
 
+[[buildpacks]]
+  uri = "docker://gcr.io/paketo-buildpacks/watchexec:2.3.3"
+  version = "2.3.3"
+
 [lifecycle]
   version = "0.13.5"
 
@@ -78,6 +82,11 @@ description = "Ubuntu bionic base image with buildpacks for Java, .NET Core, Nod
     version = "0.9.0"
 
 [[order]]
+
+  [[order.group]]
+    id = "paketo-buildpacks/watchexec"
+    optional = true
+    version = "2.3.3"
 
   [[order.group]]
     id = "paketo-buildpacks/nginx"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
so that nginx live reload workflows Just Work with the builder when
https://github.com/paketo-buildpacks/nginx/pull/343 is released

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
